### PR TITLE
Option for not drawing the icons in the gutter

### DIFF
--- a/SublimeWritingStyle.py
+++ b/SublimeWritingStyle.py
@@ -53,7 +53,10 @@ def mark_words(view, search_all=True):
             # print 'adding new regions'
             view.erase_regions(style_key)
             # name, regions, style, symbol in gutter, draw outlined
-            view.add_regions(style_key, new_regions, color_scope_name, symbol_name, draw_style)
+            if settings.theme == 'none':
+                view.add_regions(style_key, new_regions, color_scope_name, flags = draw_style)
+            else:
+                view.add_regions(style_key, new_regions, color_scope_name, symbol_name, draw_style) 
         return new_regions
         # end of lazy_mark_regions
 


### PR DESCRIPTION
Hello,

i suggest adding a new option to the settings where theme could be set to "none", which tells the package not to draw icons in the gutter. This option is valuable if one is using other packages that display icons in the gutter (e.g. GitGutter) and would like to selectively turn-off this feature; words are still underlined.

